### PR TITLE
Normalize user request

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,19 @@ SplitByPathPlugin.prototype.apply = function(compiler) {
   function findMatchingBucket(chunk) {
     var match = null;
 
+    if (!chunk.userRequest) {
+      return match;
+    }
+
+    var userRequest = chunk.userRequest;
+    var lastIndex = userRequest.lastIndexOf("!");
+    if (lastIndex !== -1) {
+      userRequest = userRequest.substring(lastIndex + 1);
+    }
+
     buckets.some(function (bucket) {
       return bucket.path.some(function (path) {
-        if (path.test(chunk.userRequest)) {
+        if (path.test(userRequest)) {
           match = bucket;
           return true;
         }


### PR DESCRIPTION
Some plugins like css-loader turns chunk.userRequest from "path-to-your-css" to "path-to-css-loader/index.js!path-to-your-css". I think the real userRequest must start from the last "!". Otherwise, the css content will go to vendors.js.
