### PR TITLE
Added ignoreChunks config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function regExpQuote(str) {
 function SplitByPathPlugin(buckets, config) {
   config = config || {};
   config.ignore = config.ignore || [];
+  config.ignoreChunks = config.ignoreChunks || [];
 
   if (!Array.isArray(config.ignore)) {
     config.ignore = [ config.ignore ];
@@ -20,7 +21,12 @@ function SplitByPathPlugin(buckets, config) {
     return new RegExp('^' + regExpQuote(item));
   });
 
+  if (!Array.isArray(config.ignoreChunks)) {
+    config.ignoreChunks = [ config.ignoreChunks ];
+  }
+
   this.ignore = config.ignore;
+  this.ignoreChunks = config.ignoreChunks;
   this.buckets = buckets.slice(0).map(function (bucket) {
     if (!Array.isArray(bucket.path)) {
       bucket.path = [ bucket.path ];
@@ -41,6 +47,7 @@ function SplitByPathPlugin(buckets, config) {
 SplitByPathPlugin.prototype.apply = function(compiler) {
   var buckets = this.buckets;
   var ignore = this.ignore;
+  var ignoreChunks = this.ignoreChunks;
 
   function findMatchingBucket(chunk) {
     var match = null;
@@ -87,7 +94,7 @@ SplitByPathPlugin.prototype.apply = function(compiler) {
       chunks
         // only parse the entry chunk
         .filter(function (chunk) {
-          return chunk.entry && chunk.name;
+          return chunk.entry && chunk.name && ignoreChunks.indexOf(chunk.name) === -1;
         })
         .forEach(function (chunk) {
           chunk.modules.slice().forEach(function (mod) {


### PR DESCRIPTION
**TL;DR**

Added an `ignoreChunks` config option to the plugin. This allows config to be:

```
new WebPackSplitByPathPlugin(
  [
    {
      name: "vendor",
      path: path.join(__dirname, "../node_modules")
    }
  ],
  {
    ignoreChunks: ["main"]
  }
)
```

And any chunk named `main` will be ignored by the split-by-path plugin.

**Longer explanation**

I encountered an edge case when attempting to use web workers and the webpack worker-loader (https://github.com/webpack/worker-loader) along with the webpack-split-by-path plugin.

Given this configuration for the plugin:

```
new WebPackSplitByPathPlugin(
      [
        {
          name: "vendor",
          path: path.join(__dirname, "../node_modules")
        }
      ])
```

My code bundle is split into "app.js" and "vendor.js" as expected. 

I also have a web worker in the code base that imports modules from node_modules. Using the webpack worker-loader means the web worker gets bundled as a separate file - as expected. However, because the web worker imports from node_modules, the split by path plugin was also splitting the web worker bundle. So instead of a single `main.worker.js`, I was getting `main.worker.js` and `vendor.worker.js`.

While this is actually pretty cool behavior, unfortunately only one of the worker files was getting loaded. And while that file did attempt to load the other worker file via `importScripts`, the other file wasn't loading. I suspect this could have been handled by modifying the worker-loader, but it was much easier to modify the split-by-path plugin to simply ignore the worker chunk altogether.

By adding an `ignoreChunk` config option and specifying the name of the web worker chunk, I now get a single worker bundle `main.worker.js` and everything loads as expected.
