### PR TITLE
Improved support with existing webpack optimization plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ new SplitByPathPlugin(chunks, options);
 - chunks - array of objects { name: string, path: string | string[] }
 - options - object, optional {
     ignore: string | string[],
-    ignoreChunks: string | string[],
-    manifest: string
+    ignoreChunks: string | string[]
   }
 
 ```js
@@ -55,7 +54,8 @@ new SplitByPathPlugin([
 var SplitByPathPlugin = require('webpack-split-by-path');
 module.exports = {
   entry: {
-    app: 'app.js'
+    app: 'app.js',
+    polyfills: 'polyfills.js'
   },
   output: {
     path: __dirname + '/public',
@@ -69,7 +69,7 @@ module.exports = {
         path: path.join(__dirname, 'node_modules')
       }
     ], {
-      manifest: 'app-entry'
+      ignoreChunks: ['polyfills']
     })
   ]
 };

--- a/example/js/polyfills.js
+++ b/example/js/polyfills.js
@@ -1,0 +1,1 @@
+// Add imports/require(s) for polyfills here

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,10 +1,12 @@
 var path = require('path');
+var webpack = require('webpack');
 var SplitByPathPlugin = require('../');
 
 module.exports = {
   entry: {
     app: path.resolve(__dirname, 'js/app.js'),
-    test: path.resolve(__dirname, 'js/test.js')
+    test: path.resolve(__dirname, 'js/test.js'),
+    polyfills: path.resolve(__dirname, 'js/polyfills.js')
   },
   output: {
     path: path.join(__dirname, 'dist'),
@@ -13,6 +15,12 @@ module.exports = {
     chunkFilename: '[name].js'
   },
   plugins: [
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'common',
+      minChunks: 1,
+      chunks: ['vendor', 'polyfills']
+    }),
+
     new SplitByPathPlugin([
       {
         name: 'vendor',
@@ -22,7 +30,9 @@ module.exports = {
         name: 'styles',
         path: path.resolve(__dirname, 'css')
       }
-    ])
+    ], {
+      ignoreChunks: ['common', 'polyfills']
+    })
   ],
   module: {
     loaders: [


### PR DESCRIPTION
- Rewrote the compilation.plugin section to use optimize-modules.
  - Using optimize-modules ensures the plugin runs before standard webpack chunk optimization plugins like the CommonsChunkPlugin.
    - Based on https://github.com/webpack/webpack/blob/webpack-1/lib/Compilation.js#L495 (applyPlugins order of execution).
  - Added this.restartApplyPlugins(); to force webpack to re-execute optimization plugins once this plugin has executed.
  - Removed use and creation of manifest chunk. The plugin only creates the chunks the user has asked it to create.
- Modified example to show how this plugin can be used in conjunction with a webpack CommonsChunkPlugin.
  - Example is rudimentary but does work.
- Added an optimize-chunks compilation.plugin function to change chunks created by this plugin to initial=false if they are empty.
  - This can happen if this plugin is used in conjunction with CommonsChunkPlugin.
  - Without this: If CommonsChunkPlugin empties a chunk this plugin creates, a chunk file will still be generated because its chunk.initial value is true.
