### PR TITLE
Feat/webpack2 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ SplitByPathPlugin.prototype.apply = function (compiler) {
       var entryChunks = chunks
         .filter(function (chunk) {
           // only parse the entry chunk
-          return chunk.entry && chunk.name && ignoreChunks.indexOf(chunk.name) === -1;
+          return chunk.hasRuntime() && chunk.name && ignoreChunks.indexOf(chunk.name) === -1;
         })
         .map(function (chunk) {
           chunk.modules
@@ -126,17 +126,15 @@ SplitByPathPlugin.prototype.apply = function (compiler) {
       // (the manifest list) for the target page.
 
       var manifestChunk = addChunk(manifestName);
-      manifestChunk.initial = manifestChunk.entry = true;
       manifestChunk.chunks = notEmptyBucketChunks.concat(entryChunks);
 
       manifestChunk.chunks.forEach(function (chunk) {
         chunk.parents = [manifestChunk];
 
-        // split chunks are all initial chunk
-        chunk.initial = true;
-
-        // set the child chunk as not entry chunk, this is important
-        chunk.entry = false;
+        chunk.entrypoints.forEach(function(ep) {
+          ep.insertChunk(manifestChunk, chunk);
+        });
+        manifestChunk.addChunk(chunk);
       });
     });
   });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 // Based on Split by Name Webpack Plugin – https://github.com/soundcloud/split-by-name-webpack-plugin
 
+var Entrypoint = require('webpack/lib/Entrypoint');
+
 function regExpQuote(str) {
   return (str + '').replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }
@@ -105,6 +107,9 @@ SplitByPathPlugin.prototype.apply = function (compiler) {
               newChunk = bucketToChunk(bucket)
               if (!newChunk) {
                 newChunk = extraChunks[bucket.name] = addChunk(bucket.name);
+                var entrypoint = new Entrypoint(bucket.name);
+                entrypoint.chunks.push(newChunk);
+                newChunk.entrypoints = [entrypoint];
               }
 
               // add the module to the new chunk
@@ -130,8 +135,7 @@ SplitByPathPlugin.prototype.apply = function (compiler) {
 
       manifestChunk.chunks.forEach(function (chunk) {
         chunk.parents = [manifestChunk];
-
-        chunk.entrypoints.forEach(function(ep) {
+        chunk.entrypoints.forEach(function (ep) {
           ep.insertChunk(manifestChunk, chunk);
         });
         manifestChunk.addChunk(chunk);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "git@github.com:BohdanTkachenko/webpack-split-by-path.git"
   },
   "keywords": [
-    "webpack"
+    "webpack",
+    "plugin"
   ],
   "author": {
     "name": "Bohdan Tkachenko",
@@ -16,7 +17,8 @@
     "url": "http://BohdanTkachenko.com"
   },
   "contributors": [
-    "SoundCloud, Nick Fisher"
+    "SoundCloud, Nick Fisher",
+    "Norbert de Langen"
   ],
   "license": "MIT",
   "bugs": {
@@ -27,9 +29,9 @@
   },
   "homepage": "https://github.com/BohdanTkachenko/webpack-split-by-path",
   "devDependencies": {
-    "webpack": "^1.13.0",
-    "css-loader": "^0.17.0",
-    "react": "^0.13.3",
-    "style-loader": "^0.12.3"
+    "webpack": "^2.1.0-beta.20",
+    "css-loader": "^0.23.1",
+    "react": "^15.3.0",
+    "style-loader": "^0.13.1"
   }
 }


### PR DESCRIPTION
This PR continues the https://github.com/BohdanTkachenko/webpack-split-by-path/pull/22 by @ndelangen

The PR fixes the entrypoints for webpack2.
I tested this change with `html-wepback-plugins` and works well (needed a small fix there as well):
https://github.com/ampedandwired/html-webpack-plugin/pull/569

@BohdanTkachenko what do you think can we ship a new beta from this PR?