### PR TITLE
upgrade to webpack3, fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,31 +93,29 @@ SplitByPathPlugin.prototype.apply = function (compiler) {
           return chunk.hasRuntime() && chunk.name && ignoreChunks.indexOf(chunk.name) === -1;
         })
         .map(function (chunk) {
-          chunk.modules
-            .slice()
-            .forEach(function (mod) {
-              var bucket = findMatchingBucket(mod, ignore, buckets);
-              var newChunk;
+          chunk.forEachModule(function (mod) {
+            var bucket = findMatchingBucket(mod, ignore, buckets);
+            var newChunk;
 
-              if (!bucket) {
-                // the module stays in the original chunk
-                return;
-              }
+            if (!bucket) {
+              // the module stays in the original chunk
+              return;
+            }
 
-              newChunk = bucketToChunk(bucket)
-              if (!newChunk) {
-                newChunk = extraChunks[bucket.name] = addChunk(bucket.name);
-                var entrypoint = new Entrypoint(bucket.name);
-                entrypoint.chunks.push(newChunk);
-                newChunk.entrypoints = [entrypoint];
-              }
+            newChunk = bucketToChunk(bucket)
+            if (!newChunk) {
+              newChunk = extraChunks[bucket.name] = addChunk(bucket.name);
+              var entrypoint = new Entrypoint(bucket.name);
+              entrypoint.chunks.push(newChunk);
+              newChunk.entrypoints = [entrypoint];
+            }
 
-              // add the module to the new chunk
-              newChunk.addModule(mod);
-              mod.addChunk(newChunk);
-              // remove it from the existing chunk
-              mod.removeChunk(chunk);
-            });
+            // add the module to the new chunk
+            newChunk.addModule(mod);
+            mod.addChunk(newChunk);
+            // remove it from the existing chunk
+            mod.removeChunk(chunk);
+          });
 
           return chunk
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-split-by-path",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Split a Webpack entry bundle into any number of arbitrarily defined smaller bundles",
   "main": "index.js",
   "repository": {
@@ -29,9 +29,9 @@
   },
   "homepage": "https://github.com/BohdanTkachenko/webpack-split-by-path",
   "devDependencies": {
-    "webpack": "^2.2.0",
-    "css-loader": "^0.25.0",
+    "webpack": "^3.0.0",
+    "css-loader": "^0.28.0",
     "react": "^15.3.2",
-    "style-loader": "^0.13.1"
+    "style-loader": "^0.18.0"
   }
 }


### PR DESCRIPTION
Upgrade to webpack 3.x by switching out `chunk.modules` for `chunk.forEachModule`.